### PR TITLE
Create jitpack.yml so jitpack.io uses java 11 and can compile this

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk11


### PR DESCRIPTION
As we are using String.strip() which was introduced in java 11 this is required.